### PR TITLE
feat(mon,rest): Upgrade rest and monitoring to 3.14.3

### DIFF
--- a/docker/fts3-mon/Containerfile
+++ b/docker/fts3-mon/Containerfile
@@ -1,33 +1,13 @@
-#> Docker image build arguments:
-
-# Build dummy django rpm
-# Fix: python3-django3 no longer exists in almalinux
-# EPEL repo. There is minor differences in django 4.2 (LTS)
-FROM almalinux:9.8 as django
-
-RUN dnf install -y rpm-build && \
-    dnf clean all && \
-    rm -rf /var/cache/dnf
-
-ADD django-provide.spec /tmp/django-provide.spec
-
-# Build the RPM
-RUN rpmbuild -bb /tmp/django-provide.spec --define "_rpmdir /tmp/dummy-repo" \
-         --define "_srcrpmdir /tmp/dummy-repo" \
-         --define "_builddir /tmp"
-
-# Main image
 FROM almalinux:9.8
 
 ARG IMAGE_VERSION=dev
 ARG S6_OVERLAY_VERSION=3.2.2.0
 
-LABEL fts-version="3.14.2" \
+LABEL fts-version="3.14.3" \
       image-version="${IMAGE_VERSION}" \
       description="FTS3 Monitoring Container" \
       maintainer="Dennis Lee <dylee@fnal.gov>" \
-      fts_monitoring_version="3.14.2" \
-      fts_mysql_version="3.14.2"
+      fts_monitoring_version="3.14.3"
 
 #> Add supported Alma9 repos
 ADD http://fts-repo.web.cern.ch/fts-repo/fts3-el9.repo \
@@ -45,17 +25,15 @@ dnf clean all
 rm -rf /var/cache/dnf
 EOF
 
-COPY --from=django /tmp/dummy-repo/x86_64/django-provide-1.0-1.el9.x86_64.rpm /tmp/
+# COPY --from=django /tmp/dummy-repo/x86_64/django-provide-1.0-1.el9.x86_64.rpm /tmp/
 
 #> Install FTS
 RUN <<EOF
 dnf install -y \
-  python3-django4.2 \
-  /tmp/django-provide-1.0-1.el9.x86_64.rpm \
-  fts-monitoring-3.14.2 \
-  fts-monitoring-selinux-3.14.2 \
-  fts-mysql-3.14.2 \
+  fts-monitoring-3.14.3 \
+  fts-monitoring-selinux-3.14.3 \
   python3-sqlalchemy \
+  gridsite \
   procps which \
   gettext vo-client \
   cronie \
@@ -65,8 +43,7 @@ rm -rf /var/cache/dnf
 
 #> Clear up cronie anacron job
 rm -f /etc/cron.d/0hourly \
-  /etc/cron.hourly/0anacron \
-  /tmp/django-provide-1.0-1.el9.x86_64.rpm
+  /etc/cron.hourly/0anacron
 
 groupmod -g 2000 fts3 2>/dev/null || true
 usermod -u 1000 -g 2000 fts3 2>/dev/null || true

--- a/docker/fts3-mon/hooks/build-daily.bash
+++ b/docker/fts3-mon/hooks/build-daily.bash
@@ -1,10 +1,11 @@
 #!/bin/bash
 
 DATE=$(date +%Y%m%d)
-FTS_VERSION=3.14.2
+FTS_VERSION=3.14.3
+IMAGE_VERSION=0.2.0
 
 podman build --platform linux/amd64 \
-  --build-arg VERSION=$FTS_VERSION \
-  -t ${1:-localbuild/fts3-mon:latest-s6-$DATE} \
-  -t ghcr.io/fnal-fife/fts3-mon:$FTS_VERSION-s6-$DATE \
+  --build-arg FTS_VERSION=$FTS_VERSION \
+  --build-arg IMAGE_VERSION=$IMAGE_VERSION \
+  -t ghcr.io/fnal-fife/fts3-mon:$FTS_VERSION-$IMAGE_VERSION-$DATE \
   -f Containerfile .

--- a/docker/fts3-mon/hooks/build.bash
+++ b/docker/fts3-mon/hooks/build.bash
@@ -1,9 +1,10 @@
 #!/bin/bash
 
-FTS_VERSION=3.14.2
+FTS_VERSION=3.14.3
+IMAGE_VERSION=0.2.0
 
 podman build --platform linux/amd64 \
-  --build-arg VERSION=$FTS_VERSION \
-  -t ${1:-localbuild/fts3-mon:latest-s6} \
-  -t ghcr.io/fnal-fife/fts3-mon:$FTS_VERSION-s6 \
+  --build-arg FTS_VERSION=$FTS_VERSION \
+  --build-arg IMAGE_VERSION=$IMAGE_VERSION \
+  -t ghcr.io/fnal-fife/fts3-mon:$FTS_VERSION-$IMAGE_VERSION \
   -f Containerfile .

--- a/docker/fts3-mon/rootfs/tmp/setup.sh
+++ b/docker/fts3-mon/rootfs/tmp/setup.sh
@@ -30,8 +30,8 @@ envsubst < /opt/fts3/fts3-configs/fts-activemq.conf > /etc/fts3/fts-activemq.con
 chown root:apache /etc/fts3web/fts3web.ini
 chown -R fts3:apache /var/log/fts3web
 
-echo ">> Set FTS3 Aliases <<"
-python3 /opt/fts3/cluster-hostname-aliasing.py
+#echo ">> Set FTS3 Aliases <<"
+#python3 /opt/fts3/cluster-hostname-aliasing.py
 
 # Remove TLSv1.3 support from monitoring server config : See https://its.cern.ch/jira/browse/FTS-2037 for more information
 sed -i -e 's^SSLProtocol all -SSLv2 -SSLv3 -TLSv1 -TLSv1.1^SSLProtocol all -SSLv2 -SSLv3 -TLSv1 -TLSv1.1 -TLSv1.3^g' /etc/httpd/conf.d/ftsmon.conf

--- a/docker/fts3-rest/Containerfile
+++ b/docker/fts3-rest/Containerfile
@@ -4,12 +4,11 @@ FROM almalinux:9.8
 ARG IMAGE_VERSION=dev
 ARG S6_OVERLAY_VERSION=3.2.2.0
 
-LABEL fts-version="3.14.2" \
+LABEL fts-version="3.14.3" \
       image-version="${IMAGE_VERSION}" \
       description="FTS3 Rest Container" \
       maintainer="Dennis Lee <dylee@fnal.gov>" \
-      fts_rest_version="3.14.2" \
-      fts_mysql_version="3.14.2"
+      fts_rest_version="3.14.3"
 
 #> Add supported Alma9 repos
 ADD http://fts-repo.web.cern.ch/fts-repo/fts3-el9.repo \
@@ -30,9 +29,8 @@ EOF
 #> Install FTS and other utils
 RUN <<EOF
 dnf install -y \
-  fts-rest-server-3.14.2 \
-  fts-rest-server-selinux-3.14.2 \
-  fts-mysql-3.14.2 \
+  fts-rest-server-3.14.3 \
+  fts-rest-server-selinux-3.14.3 \
   procps which \
   cronie \
   gettext vo-client \

--- a/docker/fts3-rest/hooks/build-daily.bash
+++ b/docker/fts3-rest/hooks/build-daily.bash
@@ -1,10 +1,12 @@
 #!/bin/bash
 
 DATE=$(date +%Y%m%d)
-FTS_VERSION=3.14.2
+FTS_VERSION=3.14.3
+IMAGE_VERSION=0.2.0
 
 podman build --platform linux/amd64 \
-  --build-arg VERSION=$FTS_VERSION \
+  --build-arg FTS_VERSION=$FTS_VERSION \
+  --build-arg IMAGE_VERSION=$IMAGE_VERSION \
   -t ${1:-localbuild/fts3-rest:latest-s6-$DATE} \
-  -t ghcr.io/fnal-fife/fts3-rest:$FTS_VERSION-s6-$DATE \
+  -t ghcr.io/fnal-fife/fts3-rest:$FTS_VERSION-$IMAGE_VERSION-$DATE \
   -f Containerfile .

--- a/docker/fts3-rest/hooks/build.bash
+++ b/docker/fts3-rest/hooks/build.bash
@@ -1,9 +1,11 @@
 #!/bin/bash
 
-FTS_VERSION=3.14.2
+FTS_VERSION=3.14.3
+IMAGE_VERSION=0.2.0
 
 podman build --platform linux/amd64 \
-  --build-arg VERSION=$FTS_VERSION \
+  --build-arg FTS_VERSION=$FTS_VERSION \
+  --build-arg IMAGE_VERSION=$IMAGE_VERSION \
   -t ${1:-localbuild/fts3-rest:latest} \
-  -t ghcr.io/fnal-fife/fts3-rest:$FTS_VERSION \
+  -t ghcr.io/fnal-fife/fts3-rest:$FTS_VERSION-$IMAGE_VERSION \
   -f Containerfile .


### PR DESCRIPTION
Upgrade rest and monitoring to 3.14.3

Monitoring 3.14.3 fixed the django requirement, so the multistage build has been removed.